### PR TITLE
[어드민] 로그인 페이지 만들기

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/config/SecurityConfig.java
@@ -16,6 +16,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
                 .formLogin(withDefaults())
                 .logout(logout -> logout.logoutSuccessUrl("/"))
+                .oauth2Login(withDefaults())
                 .build();
     }
 

--- a/src/main/resources/templates/layouts/layout-header.html
+++ b/src/main/resources/templates/layouts/layout-header.html
@@ -137,6 +137,20 @@
       </li>
       <!-- */-->
 
+      <!--/* 로그인 버튼 */-->
+      <li class="nav-item">
+        <a id="login" class="nav-link" href="#" role="button">
+          <i class="fas fa-sign-in-alt"></i>
+        </a>
+      </li>
+
+      <!--/* 로그아웃 버튼 */-->
+      <li class="nav-item">
+        <a id="logout" class="nav-link" href="#" role="button">
+          <i class="fas fa-sign-out-alt"></i>
+        </a>
+      </li>
+
       <!--/* 전체 화면 토글 버튼 */-->
       <li class="nav-item">
         <a class="nav-link" data-widget="fullscreen" href="#" role="button">

--- a/src/main/resources/templates/layouts/layout-header.th.xml
+++ b/src/main/resources/templates/layouts/layout-header.th.xml
@@ -2,4 +2,6 @@
 <thlogic>
   <attr sel="#header-nav-home" th:href="@{/}" th:text="'Home'" />
   <attr sel="#header-nav-admin-members" th:href="@{/admin/members}" th:text="'Member'" />
+  <attr sel="#login" sec:authorize="!isAuthenticated()" th:href="@{/oauth2/authorization/kakao}" />
+  <attr sel="#logout" sec:authorize="isAuthenticated()" th:href="@{/logout}" />
 </thlogic>


### PR DESCRIPTION
이 pr은 카카오 인증을 구현할 예정인 로그인, 로그아웃 버튼을 화면 상단 네비게이션 바의 우측에 추가하고
인증 기본 기능을 구현하기 위한 준비로 스프링 시큐리티 oauth2 기본 기능을 활성화함

This closes #15 